### PR TITLE
Styles version bump and icon position

### DIFF
--- a/lib/_uxrocket-clear.scss
+++ b/lib/_uxrocket-clear.scss
@@ -1,5 +1,5 @@
 /* @author Bilal Cinarli */
-$clear-version: 0.6.1;
+$clear-version: 0.6.2;
 
 /** -------------------------------------------
  	Clear Styles

--- a/lib/uxrocket.clear.js
+++ b/lib/uxrocket.clear.js
@@ -117,7 +117,7 @@
 	};
 
 	// version
-	ux.version = "0.6.1";
+	ux.version = "0.6.2";
 
 	// settings
 	ux.settings = defaults;

--- a/version.md
+++ b/version.md
@@ -1,6 +1,9 @@
-## Versiyon 0.6.1
-- FIX: Class kontrolleri yüzünden, eklenecek eleman inputun kendisi mi yoksa değil mi kontrolü eklendi.
+## Version 0.6.2
+- FIX: When both clear plugin and any other UX Rocket plugin with icon addition applied to field, overlapping clear icon and other plugin's icon position fixed.
 
-## Versiyon 0.6.0
-- DEĞİŞİKLİK: Input'un bütün CSS classları uxitd-plugin-wrap'a da eklenecek şekilde değiştirildi.
-- DEĞİŞİKLİK: `.uxitd-clear-wrap` içinden `width: auto;` tanımı kaldırıldı.
+## Version 0.6.1
+- FIX: Wrapper is excluded from the plugin binding routine
+
+## Version 0.6.0
+- CHANGE: Input's all classes now added to uxitd-plugin-wrap after binding.
+- CHANGE: `witdh: auto;` removed from `.uxitd-clear-wrap` definition


### PR DESCRIPTION
Theme specific "*-column" definitions removed. Icon position fixed when calendar or autocomplete plugin also applied to field
